### PR TITLE
Replaced `value` with `userId` in the first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Create an Option from a nullable type using `optionOf`:
 ```Kotlin
     fun getCurrentUserId() : Option<String> {
         val userId : String? = getUserId() // something which might return null
-        return optionOf(value)
+        return optionOf(userId)
     }
 ```
 


### PR DESCRIPTION
Fixed an issue with the first example where an undefined reference of `value` was passed to `optionOf(..)` instead of the nullable `userId`.